### PR TITLE
getting IP - GarbageCollector friendly

### DIFF
--- a/lib/cws/client.ts
+++ b/lib/cws/client.ts
@@ -68,6 +68,11 @@ export class WebSocket extends eventEmitter() {
       remoteFamily: address[2]
     };
   }
+  
+  public get remoteAddress(): String {
+    const address: any[] = this.external ? native.getAddress(this.external) : new Array(3);
+    return address[1];
+  }
 
   public get readyState(): number {
     return this.external ? this.OPEN : this.CLOSED;


### PR DESCRIPTION
Added extra getter for only IP itself.

remoteAddress of connection is in use more commonly than other values so there is no reason for creating new object each time we want to get ip