### PR TITLE
Improve typings for verifyClient's 'next' callback

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -75,6 +75,7 @@ export type ConnectionInfo = {
 export type BroadcastOptions = {
     binary?: boolean;
 };
+export type VerifyClientNext = (clientVerified: boolean, code?: number, name?: string) => void;
 export type ServerConfigs = {
     path?: string;
     port?: number;
@@ -85,7 +86,7 @@ export type ServerConfigs = {
     perMessageDeflate?: {
         serverNoContextTakeover: boolean;
     };
-    verifyClient?: (info: ConnectionInfo, next: Listener) => void;
+    verifyClient?: (info: ConnectionInfo, next: VerifyClientNext) => void;
 };
 export type SendOptions = {
     binary?: boolean;

--- a/dist/index.js
+++ b/dist/index.js
@@ -158,7 +158,7 @@ class WebSocketServer extends EventEmitterServer {
                     origin: t.headers[`${8 == +t.headers["sec-websocket-version"] ? "sec-websocket-origin" : "origin"}`],
                     secure: !!(t.connection instanceof tls.TLSSocket && (t.connection.authorized || t.connection.encrypted))
                 };
-                return e.verifyClient(s, (e, s = 500, n = "Client verification failed") => e ? this.handleUpgrade(t, r) : this.dropConnection(r, s, n));
+                return e.verifyClient(s, (e, s = 401, n = "Client verification failed") => e ? this.handleUpgrade(t, r) : this.dropConnection(r, s, n));
             }
             return this.handleUpgrade(t, r);
         }), this.httpServer.on("error", e => this.emit("error", e)), this.httpServer.on("upgrade", this.upgradeListener), 

--- a/dist/index.js
+++ b/dist/index.js
@@ -158,7 +158,7 @@ class WebSocketServer extends EventEmitterServer {
                     origin: t.headers[`${8 == +t.headers["sec-websocket-version"] ? "sec-websocket-origin" : "origin"}`],
                     secure: !!(t.connection instanceof tls.TLSSocket && (t.connection.authorized || t.connection.encrypted))
                 };
-                return e.verifyClient(s, (e, s, n) => e ? this.handleUpgrade(t, r) : this.dropConnection(r, s, n));
+                return e.verifyClient(s, (e, s = 500, n = "Client verification failed") => e ? this.handleUpgrade(t, r) : this.dropConnection(r, s, n));
             }
             return this.handleUpgrade(t, r);
         }), this.httpServer.on("error", e => this.emit("error", e)), this.httpServer.on("upgrade", this.upgradeListener), 

--- a/lib/cws/server.ts
+++ b/lib/cws/server.ts
@@ -98,7 +98,7 @@ export class WebSocketServer extends EventEmitterServer {
           secure: !!(req.connection instanceof TLSSocket && (req.connection.authorized || req.connection.encrypted))
         };
 
-        return configs.verifyClient(info, (clientVerified: boolean, code: number = 500, name: string = 'Client verification failed') =>
+        return configs.verifyClient(info, (clientVerified: boolean, code: number = 401, name: string = 'Client verification failed') =>
           clientVerified ? this.handleUpgrade(req, socket) : this.dropConnection(socket, code, name));
       }
 

--- a/lib/cws/server.ts
+++ b/lib/cws/server.ts
@@ -98,8 +98,8 @@ export class WebSocketServer extends EventEmitterServer {
           secure: !!(req.connection instanceof TLSSocket && (req.connection.authorized || req.connection.encrypted))
         };
 
-        return configs.verifyClient(info, (result: any, code: number, name: string) =>
-          result ? this.handleUpgrade(req, socket) : this.dropConnection(socket, code, name));
+        return configs.verifyClient(info, (clientVerified: boolean, code: number = 500, name: string = 'Client verification failed') =>
+          clientVerified ? this.handleUpgrade(req, socket) : this.dropConnection(socket, code, name));
       }
 
       return this.handleUpgrade(req, socket);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,8 @@ export type BroadcastOptions = {
   binary?: boolean
 };
 
+export type VerifyClientNext = (clientVerified: boolean, code?: number, name?: string) => void;
+
 export type ServerConfigs = {
   path?: string,
   port?: number,
@@ -27,7 +29,7 @@ export type ServerConfigs = {
   noDelay?: boolean,
   maxPayload?: number,
   perMessageDeflate?: { serverNoContextTakeover: boolean }
-  verifyClient?: (info: ConnectionInfo, next: Listener) => void
+  verifyClient?: (info: ConnectionInfo, next: VerifyClientNext) => void
 };
 
 export type SendOptions = {


### PR DESCRIPTION
This PR adds/improves typings for `next` callback of `verifyClient`.

When `next` was declared as simply `Listener`, it was difficult to understand how to use properly.

Also added default values for `code` (`500`) and `name` (`Client verification failed`) arguments used when dropping connection that failed verification.