### PR TITLE
add node API-Version 79

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ VER_59 := v9.11.2
 VER_64 := v10.10.0
 VER_67 := v11.0.0
 VER_72 := v12.0.0
+VER_79 := v13.2.0
 
 default:
 	make targets
@@ -14,6 +15,7 @@ default:
 	NODE=targets/node-$(VER_64) ABI=64 make `(uname -s)`
 	NODE=targets/node-$(VER_67) ABI=67 make `(uname -s)`
 	NODE=targets/node-$(VER_72) ABI=72 make `(uname -s)`
+	NODE=targets/node-$(VER_79) ABI=79 make `(uname -s)`
 	for f in dist/*.node; do chmod +x $$f; done
 targets:
 	mkdir targets
@@ -22,6 +24,7 @@ targets:
 	curl https://nodejs.org/dist/$(VER_64)/node-$(VER_64)-headers.tar.gz | tar xz -C targets
 	curl https://nodejs.org/dist/$(VER_67)/node-$(VER_67)-headers.tar.gz | tar xz -C targets
 	curl https://nodejs.org/dist/$(VER_72)/node-$(VER_72)-headers.tar.gz | tar xz -C targets
+	curl https://nodejs.org/dist/$(VER_79)/node-$(VER_79)-headers.tar.gz | tar xz -C targets
 Linux:
 	g++ $(CPP_SHARED) -static-libstdc++ -static-libgcc -I $$NODE/include/node -I $$NODE/src -I $$NODE/deps/uv/include -I $$NODE/deps/v8/include -I $$NODE/deps/openssl/openssl/include -I $$NODE/deps/zlib -s -o dist/cws_linux_$$ABI.node
 Darwin:


### PR DESCRIPTION
fixes the build when running node 13.