### PR TITLE
Avoid dependency on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "test": "mocha -r ts-node/register './tests/**/*.test.ts' --exit",
     "clean": "rimraf dist/bindings/*",
-    "install": "npm run build-cpp",
+    "install": "node-gyp rebuild > build_log.txt 2>&1 || exit 0",
     "build-ts": "rimraf dist/*.js && rimraf dist/*.ts && npm run lint && tsc",
     "build-cpp": "node-gyp rebuild > build_log.txt 2>&1 || exit 0"
   },


### PR DESCRIPTION
Before 0.16.1, cWS could be installed via `yarn` without `npm` installed. But that changed with 0.16.1, as the `install` script relies on `npm`.

As far as I understand, the aim was just for `install` to be an alias of `build-cpp` (then called `build-bindings`), so duplicating the contents should do.

Also, I'm worried about the `|| exit 0` part: isn't that just hiding build failures, causing issues at runtime down the line?