### PR TITLE
Send response header even if Sec-WebSocket-Key header field is invalid

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -197,9 +197,11 @@ export class WebSocketServer {
             native.upgrade(this.serverGroup, ticket, secKey, req.headers['sec-websocket-extensions'], req.headers['sec-websocket-protocol']);
           }
         });
-      }
 
-      socket.destroy();
+        socket.destroy();
+      } else {
+        return this.abortConnection(socket, 400, 'Bad Request');
+      }
     }
   }
 }


### PR DESCRIPTION
A reverse proxy like nginx with the default configuration may consider the server is unavailable for some duration when it did not receive response header, which leads to denial of service.

Send response header even if `Sec-WebSocket-Key` header field is invalid and eliminate such possibility.